### PR TITLE
Add method: Logger.Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,21 @@ func main() {
 	// singleton instance
 	// same > logger == gwlog.GetLogger() 
 	logger := gwlog.GetLogger()
+	
 	// SetFormatter (implements logrus.Formatter)
 	// Default Formatter logrus.TextFormatter
 	logger.SetFormatter(&formatter.JSONFormatter{})
+	
 	logger.Info("abc")
 	// => {"level":"INFO","message":"abc","time":"2000-01-01T00:00:00+09:00"}
+	
 	logger.WithFields(map[string]interface{}{
 		"hoge": 1,
 		"fuga": "2"
 	}).Info("abc")
 	// => {"hoge":1,"fuga":"2","level":"INFO","message":"abc","time":"2000-01-01T00:00:00+09:00"}
+    
+	logger.Type("APP").Info("abc")
+	// => {"type":"APP","level":"INFO","message":"abc","time":"2000-01-01T00:00:00+09:00"}
 }
 ```

--- a/logger.go
+++ b/logger.go
@@ -22,6 +22,9 @@ Usage
 	}).Info("aaa")
 	// Output: {"hoge":"hoge","level":"INFO","message":"aaa","time":"2000-01-01T00:00:00+09:00"}
 
+	// Type
+	logger.Type("APP").Info("aaa")
+	// Output: {"type":"APP","level":"INFO","message":"aaa","time":"2000-01-01T00:00:00+09:00"}
 */
 package gwlog
 
@@ -67,6 +70,8 @@ type Logger interface {
 	SetLevel(v log.Lvl)
 	// SetHeader is not used
 	SetHeader(h string)
+	// Type is Set Add field
+	Type(typ string) *logrus.Entry
 	// Print writes to log at log level INFO
 	Print(i ...interface{})
 	// Println writes to log with a line break at log level INFO
@@ -191,6 +196,12 @@ func (l *logger) SetLevel(level log.Lvl) {
 }
 
 func (l *logger) SetHeader(_ string) {
+}
+
+func (l *logger) Type(typ string) *logrus.Entry {
+	return l.Logger.WithFields(logrus.Fields{
+		"type": typ,
+	})
 }
 
 func (l *logger) Print(i ...interface{}) {

--- a/logger_test.go
+++ b/logger_test.go
@@ -1,0 +1,17 @@
+package gwlog
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func Test_logger_Type(t *testing.T) {
+	buf := new(bytes.Buffer)
+	logger := GetLogger()
+	logger.SetOutput(buf)
+	logger.Type("APP").Info("example")
+	if strings.Contains(buf.String(), "type=APP") == false {
+		t.Errorf("invalid format: %s", buf.String())
+	}
+}


### PR DESCRIPTION
Added Logger.Type method.

Example of use

```go
gwlog.GetLogger().Type("APP").Info("example")
```

```bash
{"type":"APP","level":"INFO","message":"abc","time":"2000-01-01T00:00:00+09:00"}
```


Make the version `1.1.0` after the merge 👍 